### PR TITLE
fix: replace deprecated marked.setOptions with marked.use for consist…

### DIFF
--- a/src/common/render-markdown.js
+++ b/src/common/render-markdown.js
@@ -2,7 +2,7 @@ import DOMPurify from "dompurify";
 import katex from "katex";
 import { marked } from "marked";
 
-marked.setOptions({
+marked.use({
   breaks: true,
   gfm: true,
 });


### PR DESCRIPTION
I looked into why assistant responses were displaying as unreadable blocks of text, with bold not rendering and line breaks not showing up. Traced the full pipeline, the markdown library, rendering approach, CSS, and the system prompt.

The frontend was using marked.setOptions() to configure the markdown library, which was deprecated in marked v5. The project is on v17, meaning this call was likely being silently ignored, and the options that handle bold (gfm: true) and line breaks (breaks: true) were never actually applied. Replaced it with marked.use(), the current supported API. Bold text and line breaks now render more reliably after this fix.

What is still not working (backend)
After the fix, responses still show formatting issues. So what I did was I added a raw response viewer to see what the backend sends before any frontend processing. The raw output confirmed the backend is the source of the remaining problems:
- The model runs the first list item onto the intro sentence with no line break (survey:- Nepal)
- Remaining list items have no - bullet markers at all, just indented
- Some responses appear to be truncated mid-sentence, suggesting the model may be hitting its output token limit

### Suggested next steps

Update the system prompt to make markdown formatting more forceful e.g. "Every list MUST use - bullet markers. No exceptions." and add a concrete example of a correctly formatted response like 

`## Output Style

- Use short paragraphs by default.
- Use headings only when they help.
- Every list MUST use `-` bullet markers. No exceptions. Never write list items as plain lines without a `-` prefix.
- Use numbered lists only for steps or sequences.
- Use tables only when content is truly tabular.
- Keep responses concise unless the user asks for depth.
- Avoid long preambles, repeated caveats, and repeated closing language.

**Example of correct list formatting:**
- Kenya
- The United Republic of Tanzania 
- The Republic of Uganda`
 
<img width="490" height="723" alt="Screenshot 2026-04-10 131248" src="https://github.com/user-attachments/assets/c0a352f1-b180-4984-b76b-6f4d3cf766f2" />

Review the output token limit configuration for Amazon Nova Pro as responses may be getting cut off, so maybe try another model