### PR TITLE
fix: retry updates existing failed message instead of creating a new one

### DIFF
--- a/src/components/dataAssistant/data-assistant.scss
+++ b/src/components/dataAssistant/data-assistant.scss
@@ -16,7 +16,7 @@
     gap: 10px;
     padding: 8px 8px 8px 12px;
     border: 1px solid rgba(255, 153, 0, 0.2);
-    border-radius: 999px;
+    border-radius: 20px;
     background: rgba(255, 255, 255, 0.98);
     box-shadow: 0 18px 34px rgba(15, 23, 42, 0.14),
       0 4px 10px rgba(15, 23, 42, 0.06);

--- a/src/components/dataAssistant/data-assistant.vue
+++ b/src/components/dataAssistant/data-assistant.vue
@@ -390,19 +390,29 @@ export default Vue.extend({
       }
 
       const question = this.lastFailedQuestion;
+      const existingMessage = [...this.messages].reverse().find(
+        (m) => m.role === "assistant" && m.errorText
+      );
       this.streamError = "";
       this.lastFailedQuestion = "";
       this.clearCopiedMessageStatus();
       this.clearConversationActionStatus();
-      await this.startAssistantStream(question);
+      await this.startAssistantStream(question, existingMessage);
     },
-    async startAssistantStream(question) {
+    async startAssistantStream(question, existingMessage = null) {
       this.abortActiveRequest();
 
-      const assistantMessage = this.buildMessage("assistant");
+      const assistantMessage = existingMessage || this.buildMessage("assistant");
+      assistantMessage.text = "";
+      assistantMessage.errorText = "";
       assistantMessage.isThinking = true;
       assistantMessage.thinkingText = this.currentCopy.thinking;
-      this.messages.push(assistantMessage);
+      assistantMessage.isStreaming = false;
+
+      if (!existingMessage) {
+        this.messages.push(assistantMessage);
+      }
+
       this.scrollToBottom();
 
       const controller =


### PR DESCRIPTION
### This PR introduces
When the stream fails and the user clicks Retry, a new assistant message was being created and appended below the failed one instead of updating it. This leaves the user with two messages, the error message and the new response(if the second one was an error, 2 errors messages and so on), which was confusing and not user-friendly.

So, I updated the retry logic in data-assistant.vue to find the existing failed message and pass it into the stream handler. Instead of creating a new message, the stream now resets and reuses the failed one. And  normal message sending is completely untouched.
<img width="514" height="751" alt="Screenshot 2026-04-13 093156" src="https://github.com/user-attachments/assets/01a7716f-14b7-4a1a-8f49-266e99445749" />
<img width="506" height="746" alt="Screenshot 2026-04-13 093220" src="https://github.com/user-attachments/assets/bf9dcd27-699b-4b45-8b6e-e83f0a146dd5" />
<img width="505" height="742" alt="Screenshot 2026-04-13 093231" src="https://github.com/user-attachments/assets/fc6734e8-05d6-4b3c-ad6c-a07ae081a5eb" />


### Additionally
The outer border of the launcher button should have the same roundness  to the inner border wrapping the bot logo. 

<img width="276" height="177" alt="Screenshot 2026-04-13 110909" src="https://github.com/user-attachments/assets/9e3f83a4-0747-41e3-ae4b-d4bc4103e8ba" />
