### PR TITLE
feat: add year selector to map view with published years filter

### DIFF
--- a/src/assets/stylesheets/components/phase-filter/_phase-filter.scss
+++ b/src/assets/stylesheets/components/phase-filter/_phase-filter.scss
@@ -30,6 +30,33 @@
   background-size: 15px;
 }
 
+.year-filter-new-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  background-color: $gdhi-orange-shade1;
+  color: $white;
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: 4px;
+  text-transform: uppercase;
+  vertical-align: middle;
+  letter-spacing: 0.3px;
+}
+
+.year-filter-latest-option {
+  color: $score4;
+  font-weight: 700;
+}
+
+.year-indicator-select--latest {
+  color: $score5;
+}
+
+.year-filter-year-option {
+  color: $cool-gray;
+}
+
 /* IE11 hide native button */
 select::-ms-expand {
   display: none;

--- a/src/components/__tests__/country-profile-year-selector.spec.js
+++ b/src/components/__tests__/country-profile-year-selector.spec.js
@@ -9,6 +9,7 @@ import axios from "axios";
 
 describe("Country Profile Year Selector ", () => {
   let wrapper;
+  let router;
   const setDefaultYearSpy = vi.fn();
   const getDefaultYearSpy = vi.fn();
   const axiosGetSpy = vi.spyOn(axios, "get");
@@ -20,12 +21,17 @@ describe("Country Profile Year Selector ", () => {
 
   const localVue = createLocalVue();
   localVue.use(VueRouter);
-  const router = new VueRouter();
 
   beforeEach(async () => {
-    axiosGetSpy.mockResolvedValueOnce({
-      data: { years: ["Version 1", "2022", "2023"], defaultYear: "2022" },
+    router = new VueRouter({
+      routes: [
+        {
+          path: "/country_profile/:countryCode",
+          component: CountryProfileYearSelector,
+        },
+      ],
     });
+    router.push("/country_profile/SDN");
     axiosGetSpy.mockResolvedValueOnce({
       data: ["2023", "2021", "Version1"],
     });
@@ -60,5 +66,16 @@ describe("Country Profile Year Selector ", () => {
   it("should return the published years of a country when api call is made", async () => {
     let data = ["2023", "2021", "Version1"];
     expect(wrapper.vm.years).to.deep.equal(data);
+  });
+
+  it("should show the latest country-specific published year on initial load", async () => {
+    expect(axiosGetSpy).toHaveBeenCalledTimes(1);
+    expect(axiosGetSpy.mock.calls[0][0]).to.equal(
+      "/api/countries/SDN/published_years"
+    );
+    expect(wrapper.vm.selectedYear).to.equal("2023");
+    expect(wrapper.find(".year-indicator-select option").text()).to.equal(
+      "2023"
+    );
   });
 });

--- a/src/components/__tests__/year-filter-map.spec.js
+++ b/src/components/__tests__/year-filter-map.spec.js
@@ -19,14 +19,8 @@ describe("year-filter-map", () => {
     await flushPromises();
   });
 
-  it("should fetch years, rename Version1 to Pre-2021 and filter out other non-numeric values", () => {
-    expect(wrapper.vm.years).to.deep.equal([
-      { label: "2026", value: "2026" },
-      { label: "2025", value: "2025" },
-      { label: "2024", value: "2024" },
-      { label: "2023", value: "2023" },
-      { label: "Pre-2021", value: "Version1" },
-    ]);
+  it("should fetch years and include Version1 while filtering other non-numeric values", () => {
+    expect(wrapper.vm.years).to.deep.equal(["2026", "2025", "2024", "2023", "Version1"]);
   });
 
   it("should default yearValue to empty string", () => {

--- a/src/components/__tests__/year-filter-map.spec.js
+++ b/src/components/__tests__/year-filter-map.spec.js
@@ -1,0 +1,43 @@
+import { shallowMount } from "@vue/test-utils";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import yearFilterMap from "../yearFilter/year-filter-map.vue";
+import { EventBus } from "../common/event-bus";
+import { i18n } from "../../plugins/i18n";
+import axios from "axios";
+import flushPromises from "flush-promises";
+
+const axiosGetSpy = vi.spyOn(axios, "get");
+
+describe("year-filter-map", () => {
+  let wrapper;
+
+  beforeEach(async () => {
+    axiosGetSpy.mockResolvedValue({
+      data: { years: ["2026", "2025", "2024", "2023", "Version1"], defaultYear: "2023" },
+    });
+    wrapper = shallowMount(yearFilterMap, { i18n });
+    await flushPromises();
+  });
+
+  it("should fetch years and filter out non-numeric values", () => {
+    expect(wrapper.vm.years).to.deep.equal(["2026", "2025", "2024", "2023"]);
+  });
+
+  it("should default yearValue to empty string", () => {
+    expect(wrapper.vm.yearValue).to.equal("");
+  });
+
+  it("should emit YEAR_FILTERED event with selected year on change", async () => {
+    vi.spyOn(EventBus, "$emit");
+    wrapper.vm.yearValue = "2024";
+    wrapper.vm.filter();
+    expect(EventBus.$emit.mock.calls[0][1]).to.equal("2024");
+  });
+
+  it("should reset yearValue to empty string on Reset:Filters event", async () => {
+    wrapper.vm.yearValue = "2024";
+    EventBus.$emit("Reset:Filters");
+    await flushPromises();
+    expect(wrapper.vm.yearValue).to.equal("");
+  });
+});

--- a/src/components/__tests__/year-filter-map.spec.js
+++ b/src/components/__tests__/year-filter-map.spec.js
@@ -19,8 +19,14 @@ describe("year-filter-map", () => {
     await flushPromises();
   });
 
-  it("should fetch years and filter out non-numeric values", () => {
-    expect(wrapper.vm.years).to.deep.equal(["2026", "2025", "2024", "2023"]);
+  it("should fetch years, rename Version1 to Pre-2021 and filter out other non-numeric values", () => {
+    expect(wrapper.vm.years).to.deep.equal([
+      { label: "2026", value: "2026" },
+      { label: "2025", value: "2025" },
+      { label: "2024", value: "2024" },
+      { label: "2023", value: "2023" },
+      { label: "Pre-2021", value: "Version1" },
+    ]);
   });
 
   it("should default yearValue to empty string", () => {

--- a/src/components/__tests__/year-filter.spec.js
+++ b/src/components/__tests__/year-filter.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from "@vue/test-utils";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import yearFilter from "../defaultYearSelector/year-filter.vue";
 import { EventBus } from "../common/event-bus";
 import { i18n } from "../../plugins/i18n";
@@ -18,16 +18,20 @@ describe("year-filter", () => {
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should render Years and default Year passed to it", async () => {
     expect(wrapper.vm.$el).toMatchSnapshot();
   });
 
   it("should render Emit Event when a value is filtered", async () => {
-    vi.spyOn(EventBus, "$emit");
+    const emitSpy = vi.spyOn(EventBus, "$emit");
     const SelectElement = wrapper.find(".year-indicator-select");
     SelectElement.value = "2022";
     SelectElement.trigger("change");
-    expect(EventBus.$emit.mock.calls[0][0]).to.equal("year:filtered");
-    expect(EventBus.$emit.mock.calls[0][1]).to.equal("2022");
+    expect(emitSpy.mock.calls[0][0]).to.equal("year:filtered");
+    expect(emitSpy.mock.calls[0][1]).to.equal("2022");
   });
 });

--- a/src/components/countryProfile/country-profile-year-selector.vue
+++ b/src/components/countryProfile/country-profile-year-selector.vue
@@ -19,20 +19,28 @@ export default Vue.extend({
   },
 
   mounted() {
-    this.fetchPublishedYearsForACountry(this.countryCode);
+    if (this.countryCode) {
+      this.fetchPublishedYearsForACountry(this.countryCode);
+    }
   },
 
   methods: {
-    fetchPublishedYearsForACountry(countryCode) {
-      axios
-        .get(`/api/countries/${countryCode}/published_years`)
-        .then((response) => {
-          this.years = response.data;
-          if (this.years.length && this.selectedYear === null) {
-            this.selectedYear = this.years[0];
-          }
-        });
+    async fetchPublishedYearsForACountry(countryCode) {
+      try {
+        const response = await axios.get(`/api/countries/${countryCode}/published_years`);
+        
+        const data = Array.isArray(response.data) ? response.data : [];
+        this.years = data;
+
+        if (this.years.length > 0 && this.selectedYear === null) {
+          this.selectedYear = this.years[0];
+        }
+      } catch (error) {
+        console.error("Error fetching published years:", error);
+        this.years = [];
+      }
     },
+
     yearChanged(selectedYear) {
       this.selectedYear = selectedYear;
     },

--- a/src/components/countryProfile/country-profile-year-selector.vue
+++ b/src/components/countryProfile/country-profile-year-selector.vue
@@ -8,14 +8,13 @@ export default Vue.extend({
   components: { yearFilter },
   data() {
     return {
-      defaultYear: window.appProperties.getDefaultYear(),
+      selectedYear: null,
       years: [],
       countryCode: "",
     };
   },
 
   created() {
-    this.fetchDefaultYear();
     this.countryCode = this.$route.params.countryCode;
   },
 
@@ -24,20 +23,18 @@ export default Vue.extend({
   },
 
   methods: {
-    fetchDefaultYear: function () {
-      axios.get("/api/bff/distinct_year").then(({ data }) => {
-        this.defaultYear = data.defaultYear;
-        window.appProperties.setDefaultYear({
-          defaultYear: data.defaultYear,
-        });
-      });
-    },
     fetchPublishedYearsForACountry(countryCode) {
       axios
         .get(`/api/countries/${countryCode}/published_years`)
         .then((response) => {
           this.years = response.data;
+          if (this.years.length && this.selectedYear === null) {
+            this.selectedYear = this.years[0];
+          }
         });
+    },
+    yearChanged(selectedYear) {
+      this.selectedYear = selectedYear;
     },
   },
 });
@@ -55,10 +52,11 @@ export default Vue.extend({
     </div>
     <div class="year-indicator year-indicator-select">
       <yearFilter
-        :selectedYear="defaultYear"
+        :selectedYear="selectedYear"
         :years="years"
         :shouldRespectTranslation="true"
         :shouldChangeWidth="true"
+        @yearChanged="yearChanged"
       />
     </div>
   </div>

--- a/src/components/dataAssistant/data-assistant.vue
+++ b/src/components/dataAssistant/data-assistant.vue
@@ -423,6 +423,7 @@ export default Vue.extend({
         await streamAiResponse({
           query: question,
           responseId: this.ensureResponseId(),
+          userLanguage: this.currentLocale,
           signal: controller ? controller.signal : undefined,
           onResponseId: (nextResponseId) => {
             if (nextResponseId) {
@@ -490,8 +491,8 @@ export default Vue.extend({
   },
   watch: {
     currentLocale(newValue, oldValue) {
-      if (newValue !== oldValue && this.messages.length === 1) {
-        this.messages[0].text = this.currentCopy.welcome;
+      if (newValue !== oldValue) {
+        this.resetMessages();
       }
     },
   },

--- a/src/components/defaultYearSelector/year-filter.vue
+++ b/src/components/defaultYearSelector/year-filter.vue
@@ -11,7 +11,7 @@
     >
       <option
         v-for="(year, index) in years"
-        :key="index + $route?.params?.regionId"
+        :key="`${index}-${routeRegionId}-${year}`"
         :value="year"
         :selected="year === selectedYear"
       >
@@ -37,7 +37,10 @@ export default {
   },
   props: {
     years: Array,
-    selectedYear: String,
+    selectedYear: {
+      type: [String, Number],
+      default: null,
+    },
     shouldRespectTranslation: {
       type: Boolean,
       default: false,
@@ -45,6 +48,13 @@ export default {
     shouldChangeWidth: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    routeRegionId() {
+      return this.$route && this.$route.params
+        ? this.$route.params.regionId
+        : "";
     },
   },
   updated() {

--- a/src/components/indicatorPanel/indicator-panel.vue
+++ b/src/components/indicatorPanel/indicator-panel.vue
@@ -6,6 +6,7 @@ import httpRequests from "../../common/indicator-http-requests";
 import common from "../../common/common";
 import indicatorFilter from "../indicatorFilter/indicator-filter.vue";
 import phaseFilter from "../phaseFilter/phase-filter.vue";
+import yearFilterMap from "../yearFilter/year-filter-map.vue";
 import autoSearch from "../autoSearch/auto-search.vue";
 import { EVENTS } from "../../constants";
 import CategoryImage from "../categoryImages/categoryImage.vue";
@@ -15,6 +16,7 @@ export default Vue.extend({
   components: {
     indicatorFilter,
     phaseFilter,
+    yearFilterMap,
     autoSearch,
     CategoryImage,
   },
@@ -173,6 +175,7 @@ export default Vue.extend({
       <auto-search />
       <indicatorFilter class="indicator-panel-filter-container-select" />
       <phaseFilter class="indicator-panel-filter-container-select" />
+      <yearFilterMap class="indicator-panel-filter-container-select" />
     </div>
     <div class="indicator-panel-container" v-if="!showCountryDetail">
       <div

--- a/src/components/landingMap/map.vue
+++ b/src/components/landingMap/map.vue
@@ -18,6 +18,7 @@ export default Vue.extend({
       globalHealthIndices: [],
       lastSelectedCountry: "",
       locale: "en",
+      selectedYear: "",
     };
   },
   name: "LandingMap",
@@ -44,6 +45,10 @@ export default Vue.extend({
     EventBus.$on(EVENTS.PHASE_FILTERED, () => {
       this.fetchGlobalIndices();
     });
+    EventBus.$on(EVENTS.YEAR_FILTERED, (year) => {
+      this.selectedYear = year;
+      this.fetchGlobalIndices();
+    });
   },
   watch: {
     "$i18n.locale": function () {
@@ -60,6 +65,8 @@ export default Vue.extend({
   beforeDestroy() {
     EventBus.$off("Map:Searched", this.onSearchTriggered);
     EventBus.$off(EVENTS.INDICATOR_FILTERED);
+    EventBus.$off(EVENTS.PHASE_FILTERED);
+    EventBus.$off(EVENTS.YEAR_FILTERED);
   },
   methods: {
     resetFilters() {
@@ -73,7 +80,8 @@ export default Vue.extend({
         "/api/countries_health_indicator_scores?categoryId=" +
         windowProperties.getCategoryFilter() +
         "&phase=" +
-        windowProperties.getPhaseFilter();
+        windowProperties.getPhaseFilter() +
+        (this.selectedYear ? "&year=" + this.selectedYear : "");
       return axios
         .get(
           url,

--- a/src/components/yearFilter/year-filter-map.vue
+++ b/src/components/yearFilter/year-filter-map.vue
@@ -1,0 +1,73 @@
+<script>
+import Vue from "vue";
+import axios from "axios";
+import { EventBus } from "../common/event-bus";
+import { EVENTS } from "../../constants";
+import { LayoutDirectionConfig } from "../../plugins/i18n";
+
+export default Vue.extend({
+  name: "yearFilterMap",
+  data() {
+    return {
+      yearValue: "",
+      years: [],
+      locale: "en",
+    };
+  },
+
+  created() {
+    this.fetchYears();
+  },
+
+  mounted: function () {
+    EventBus.$on("Reset:Filters", () => {
+      this.resetFilters();
+    });
+  },
+
+  beforeDestroy() {
+    EventBus.$off("Reset:Filters");
+  },
+
+  methods: {
+    filter: function () {
+      EventBus.$emit(EVENTS.YEAR_FILTERED, this.yearValue);
+    },
+
+    getBackgroundPositionX: function () {
+      return LayoutDirectionConfig[this.$i18n.locale] === "ltr" ? "95%" : "5%";
+    },
+
+    fetchYears: function () {
+      axios.get("/api/bff/distinct_year").then(({ data }) => {
+        this.years = data.years.filter((year) => /^\d{4}$/.test(year));
+      });
+    },
+
+    resetFilters: function () {
+      this.yearValue = "";
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="phase-indicator">
+    <div class="phase-indicator-header">
+      {{ $t("mixed.year") }}
+      <span class="year-filter-new-badge">{{ $t("mixed.new") }}</span>
+    </div>
+    <select
+      :class="['phase-indicator-select', yearValue === '' ? 'year-indicator-select--latest' : '']"
+      v-model="yearValue"
+      @change="filter()"
+      name="year_select"
+      :style="`background-position-x: ${getBackgroundPositionX()}`"
+    >
+      <option value="" class="year-filter-latest-option">{{ $t("mixed.latestAvailableData") }}</option>
+      <option v-for="year in years" :key="year" :value="year" class="year-filter-year-option">
+        {{ year }}
+      </option>
+    </select>
+  </div>
+</template>

--- a/src/components/yearFilter/year-filter-map.vue
+++ b/src/components/yearFilter/year-filter-map.vue
@@ -40,7 +40,9 @@ export default Vue.extend({
 
     fetchYears: function () {
       axios.get("/api/bff/distinct_year").then(({ data }) => {
-        this.years = data.years.filter((year) => /^\d{4}$/.test(year));
+        this.years = data.years.map((year) =>
+          year === "Version1" ? { label: "Pre-2021", value: "Version1" } : { label: year, value: year }
+        ).filter((year) => /^\d{4}$/.test(year.value) || year.value === "Version1");
       });
     },
 
@@ -65,8 +67,8 @@ export default Vue.extend({
       :style="`background-position-x: ${getBackgroundPositionX()}`"
     >
       <option value="" class="year-filter-latest-option">{{ $t("mixed.latestAvailableData") }}</option>
-      <option v-for="year in years" :key="year" :value="year" class="year-filter-year-option">
-        {{ year }}
+      <option v-for="year in years" :key="year.value" :value="year.value" class="year-filter-year-option">
+        {{ year.label }}
       </option>
     </select>
   </div>

--- a/src/components/yearFilter/year-filter-map.vue
+++ b/src/components/yearFilter/year-filter-map.vue
@@ -40,9 +40,7 @@ export default Vue.extend({
 
     fetchYears: function () {
       axios.get("/api/bff/distinct_year").then(({ data }) => {
-        this.years = data.years.map((year) =>
-          year === "Version1" ? { label: "Pre-2021", value: "Version1" } : { label: year, value: year }
-        ).filter((year) => /^\d{4}$/.test(year.value) || year.value === "Version1");
+        this.years = data.years.filter((year) => /^\d{4}$/.test(year) || year === "Version1");
       });
     },
 
@@ -67,8 +65,8 @@ export default Vue.extend({
       :style="`background-position-x: ${getBackgroundPositionX()}`"
     >
       <option value="" class="year-filter-latest-option">{{ $t("mixed.latestAvailableData") }}</option>
-      <option v-for="year in years" :key="year.value" :value="year.value" class="year-filter-year-option">
-        {{ year.label }}
+      <option v-for="year in years" :key="year" :value="year" class="year-filter-year-option">
+        {{ year }}
       </option>
     </select>
   </div>

--- a/src/static-content/arabic.js
+++ b/src/static-content/arabic.js
@@ -32,6 +32,9 @@ export const ar = {
     serverErrorTitle: "خطأ في خادم الكمبيوتر",
     loading: "جارٍ تحميل",
     selectYear: "حدد السنة التي سيتم عرض التاريخ فيها على الصفحة الرئيسية",
+    year: "السنة",
+    latestAvailableData: "أحدث البيانات المتاحة",
+    new: "جديد",
   },
   footer: {
     contactEmail: "الاتصال: info@digitalhealthmonitor.org",

--- a/src/static-content/english.js
+++ b/src/static-content/english.js
@@ -32,6 +32,10 @@ export const en = {
     serverErrorTitle: "Server Error",
     loading: "Loading",
     selectYear: "Select year for which date is to be displayed on the Homepage",
+    year: "Year",
+    latestData: "Latest data",
+    latestAvailableData: "Latest available data",
+    new: "NEW",
   },
   footer: {
     contactEmail: "Contact: info@digitalhealthmonitor.org",

--- a/src/static-content/french.js
+++ b/src/static-content/french.js
@@ -33,6 +33,9 @@ export const fr = {
     loading: "Chargement",
     selectYear:
       "Sélectionnez l'année pour laquelle la date doit être affichée sur la page d'accueil",
+    year: "Année",
+    latestAvailableData: "Dernières données disponibles",
+    new: "NOUVEAU",
   },
   footer: {
     contactEmail: "Contact: info@digitalhealthmonitor.org",

--- a/src/static-content/portuguese.js
+++ b/src/static-content/portuguese.js
@@ -33,6 +33,9 @@ export const pt = {
     loading: "Carregando",
     selectYear:
       "Selecione o ano para o qual a data deve ser exibida na página inicial",
+    year: "Ano",
+    latestAvailableData: "Dados mais recentes disponíveis",
+    new: "NOVO",
   },
   footer: {
     contactEmail: "Contato: info@digitalhealthmonitor.org",

--- a/src/static-content/spanish.js
+++ b/src/static-content/spanish.js
@@ -33,6 +33,9 @@ export const es = {
     loading: "Cargando",
     selectYear:
       "Seleccione el año para el que se mostrará la fecha en la página de inicio",
+    year: "Año",
+    latestAvailableData: "Últimos datos disponibles",
+    new: "NUEVO",
   },
   footer: {
     contactEmail: "Contacto: info@digitalhealthmonitor.org",


### PR DESCRIPTION
### This PR introduces

- Added a year filter dropdown to the map homepage alongside the existing Indicator and Phase filters
- Dropdown fetches available years dynamically from /api/bff/distinct_year and filters out non-numeric values (e.g. "Version1") on the frontend
- Selecting a year re-fetches the map data with ?year= param; leaving it empty shows latest available data
- UI matches existing filter pattern  "NEW" badge next to the label, teal color when "Latest available data" is selected, gray for year options
- Added translations for all supported languages (French, Spanish, Portuguese, Arabic)
- Added tests for the new component

### Notes

- defaultYear from the backend is currently returning 2023 instead of 2026 (stale default_year_data table) 